### PR TITLE
ADHOC-FIX (update config values) Change behavior to insert or update

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -187,11 +187,16 @@
   shell:
     cmd: |
       mysql --user="{{ magento_config_db.username }}" --password="{{ magento_config_db.password }}" --database="{{ magento_config_db.name }}" --host="{{ magento_config_db.host }}" <<EOF
-        UPDATE core_config_data
-          SET value = '{{ item.value | regex_replace('\[\[', '{{') | regex_replace('\]\]', '}}') }}'
-          WHERE path = '{{ item.path }}' AND
-            scope = '{{ item.scope }}' AND
-            scope_id = {{ item.scope_id }};
+        INSERT INTO core_config_data (path, scope, scope_id, value)
+          VALUES (
+             '{{ item.path }}',
+             '{{ item.scope }}',
+             {{ item.scope_id }},
+             '{{ item.value | regex_replace('\[\[', '{{') | regex_replace('\]\]', '}}') }}'
+          )
+          ON DUPLICATE KEY UPDATE
+             value = '{{ item.value | regex_replace('\[\[', '{{') | regex_replace('\]\]', '}}') }}'
+          ;
       EOF
   with_items: "{{ magento_core_config_data }}"
 


### PR DESCRIPTION
As discovered on showroom deployment, the config value for the base_url
was not set. This results in an showroom where no links are working in
Magento. My assumption in using this is that when I am setting magento
core configuration data via `magento_core_config_data` variable from
ansible, is that this values are set after the deployment.

Actualy this was only the case if this setting is already existing in
the database. Changing to an `insert` statement with `ON DUPLICATE KEY
UPDATE` is an esy way to achive this behavior. As there is an
'UNIQUE KEY `CORE_CONFIG_DATA_SCOPE_SCOPE_ID_PATH` (`scope`,`scope_id`,`path`)'
for the `core_config_data` table.