### PR TITLE
AdHoc (setup) Fix recursive error while preparing release folder

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -5,6 +5,7 @@
     path: "{{ magento_release_folder }}"
     state: "directory"
     recurse: "yes"
+    follow: no
     owner: "{{ magento_user }}"
     group: "{{ magento_group }}"
     mode: "u=rwx,g=rx,o=rx"


### PR DESCRIPTION
While running the deployment, it comes to an
RuntimeError: maximum recursion depth exceeded in __instancecheck_
This was caused by following some symlinks. This symlinks should
not be followed. Adding the 'no follow' option helps preventing this
error.

This fix was inspired by
https://github.com/ansible/ansible/issues/39456