### PR TITLE
ADHOC feat (cleaup): auto-cleanup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -294,6 +294,6 @@ magento_queue_consumers_cron_template: "/usr/bin/php {{ magento_app_root }}/bin/
 ## Deletes all installed deployable magento packages except the 
 ## %magento_clones_to_keep% amount of latest ones + all that are newer than
 ## %magento_clones_cleanup_min_age%
-magento_cleanup_old_clones: False
+magento_cleanup_old_clones: True
 magento_clones_to_keep: 5
 magento_clones_cleanup_min_age: "1d"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -290,3 +290,9 @@ magento_upgrade_commands:
 magento_run_message_queue_consumers_separately: false
 
 magento_queue_consumers_cron_template: "/usr/bin/php {{ magento_app_root }}/bin/magento queue:consumers:start {{ item.name }}"
+
+## Deletes all installed deployable magento packages except the 
+## %magento_clones_to_keep% amount of latest ones + the one that is being 
+## deployed right now.
+magento_cleanup_old_clones: False
+magento_clones_to_keep: 5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -292,7 +292,8 @@ magento_run_message_queue_consumers_separately: false
 magento_queue_consumers_cron_template: "/usr/bin/php {{ magento_app_root }}/bin/magento queue:consumers:start {{ item.name }}"
 
 ## Deletes all installed deployable magento packages except the 
-## %magento_clones_to_keep% amount of latest ones + the one that is being 
-## deployed right now.
+## %magento_clones_to_keep% amount of latest ones + all that are newer than
+## %magento_clones_cleanup_min_age%
 magento_cleanup_old_clones: False
 magento_clones_to_keep: 5
+magento_clones_cleanup_min_age: "1d"

--- a/tasks/cleanup-old-clones.yml
+++ b/tasks/cleanup-old-clones.yml
@@ -1,7 +1,15 @@
 ---
-- name: "Cleanup old clones"
-  become: "yes"
-  become_user: "{{ magento_user }}"
-  shell: "find {{ magento_release_folder }} -maxdepth 1 -mindepth 1  ! \\( -name \"{{ magento_release_version }}\" \\) -type d -printf '%T@:%p\n' | sort -r | tail --lines=+{{ magento_clones_to_keep }} | awk -F: '{ print $2 }' | xargs -t rm -rf ;"
-  when:
-    - magento_cleanup_old_clones == True
+- name: "Discover old clone/release directories which need to be cleaned"
+  find:
+    paths: "{{ magento_release_folder }}"
+    age: "{{ magento_clones_cleanup_min_age }}"
+    file_type: directory
+    age_stamp: "ctime"
+  register: magento_clones_for_cleanup
+
+- name: "Remove old clones/releases"
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  when: magento_cleanup_old_clones == True
+  with_items: "{{ (magento_clones_for_cleanup.files | sort(attribute='ctime', reverse=True))[magento_clones_to_keep:] | list }}"

--- a/tasks/cleanup-old-clones.yml
+++ b/tasks/cleanup-old-clones.yml
@@ -1,0 +1,7 @@
+---
+- name: "Cleanup old clones"
+  become: "yes"
+  become_user: "{{ magento_user }}"
+  shell: "find {{ magento_release_folder }} -maxdepth 1 -mindepth 1  ! \\( -name \"{{ magento_release_version }}\" \\) -type d -printf '%T@:%p\n' | sort -r | tail --lines=+{{ magento_clones_to_keep }} | awk -F: '{ print $2 }' | xargs -t rm -rf ;"
+  when:
+    - magento_cleanup_old_clones == True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,4 +3,5 @@
 - include: "setup.yml"
 - include: "installation.yml"
 - include: "message-queue-consumers.yml"
+- include: "cleanup-old-clones.yml"
 - include: "admin.yml"


### PR DESCRIPTION
    automatic cleanup of older clones to keep the disk usage under control. Those
    clones/releases are usually around 1GB in size, having 30 of them on the
    machine is easy within a week if project is atively developed. That means that
    most of this space is pretty much wasted, cause all those clones are anyways
    stored in AWS/Azure we don't need to keep them on the machine for backup
    purposes or whatsoever. We only need few recent ones to ensure fast roll-back
    in case of failed deploy.
    
    The roll back is expected to be performed manually as of now. There is no
    automation prepared or planned for it at the moment.
    
    Using `shell` and not `command` here cause `command` is not able to interpret
    `\(` correctly and pass that to the actual shell. It is an element of `find`
    parameter syntax, we are using a construct there to do a negation.
    
    The actual one-liner command was borrowed from other project where release
    activation/deployment is done with a shell script, so the command itself is
    battle-proven.
