### PR TITLE
AHOC feat (installation): let indexer run

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -297,3 +297,8 @@ magento_queue_consumers_cron_template: "/usr/bin/php {{ magento_app_root }}/bin/
 magento_cleanup_old_clones: True
 magento_clones_to_keep: 5
 magento_clones_cleanup_min_age: "1d"
+
+## Enforces indexer run on every deploy
+## by default indexer will run only in case database was created from scratch.
+## In case you need to refresh indexes on deploy (e.g. to fill search index) - set this to true.
+magento_force_reindex_on_deploy: False

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -211,6 +211,11 @@
   become_user: "{{ magento_user }}"
   command: "/usr/bin/php {{ magento_app_root }}/bin/magento cache:flush"
 
+- name: "Let Magento indexer run"
+  become: "yes"
+  become_user: "{{ magento_user }}"
+  command: "/usr/bin/php {{ magento_app_root }}/bin/magento indexer:reindex"
+
 - name: "Disable maintenance mode"
   file:
     path: "{{ magento_release_folder }}/{{ magento_release_version }}/var/.maintenance.flag"

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -215,6 +215,7 @@
   become: "yes"
   become_user: "{{ magento_user }}"
   command: "/usr/bin/php {{ magento_app_root }}/bin/magento indexer:reindex"
+  when: magento_db_status.stdout_lines|length == 0 or magento_force_reindex_on_deploy == True
 
 - name: "Disable maintenance mode"
   file:


### PR DESCRIPTION
it is important to run magento indexer upon installation, cause it fills
index tables with initial data, it also fills elasticsearch on the first run.

Without running indexer magento is not fully operational after first deploy.