### PR TITLE
fix (performance): remove recurse

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -4,8 +4,6 @@
   file:
     path: "{{ magento_release_folder }}"
     state: "directory"
-    recurse: "yes"
-    follow: no
     owner: "{{ magento_user }}"
     group: "{{ magento_group }}"
     mode: "u=rwx,g=rx,o=rx"


### PR DESCRIPTION
Removing the "recurse" flag cause it explodes after the first deploy.
I assume it is slow here cause Magento has a lot of files and once we have
multiple clones in the `clones` folder Ansible is iterating over ALL of them
and checks and corrects permissions and other atrributes, this is super SLOW.
It makes Ansible to hang on this step for 30 minutes easily if we have 15 clones
for example.

The recurse was failing before due to symlinks inside the actual clones and
was fixed in previous work by introducing a no-follow flag. Well that fixes the
problem of ansible breaking, but performance is just terrible.
On top of that we don't need to fix permissions of actual clones, cause we
actually correct them when we do actual download of the clone.