### PR TITLE
AdHoc (fix) undefined variable Error

### DIFF
--- a/templates/etc/env.php.j2
+++ b/templates/etc/env.php.j2
@@ -113,7 +113,7 @@ return array (
   array (
     'date' => '{{ magento_install_date }}',
   ),
-  {% if magento_queue_amqp %}
+  {% if magento_queue_amqp is defined %}
   'queue' =>
   array (
     'amqp' =>


### PR DESCRIPTION
In commit c4b8b721d0863a25cd60aa24ef71f07879cb5181 there was introduced
an if statement, in an template. This if statement fails, because the
variable is not defined in this role. Leading to an "variable undefined"
error, in case this variable is not set in the project.

This is to fix this issue.