### PR TITLE
ADHOC feat redis-cache: force expiry for (almost) all cache entries

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -232,6 +232,8 @@ magento_x_frame_options: "SAMEORIGIN"
 #   database: 1
 #   password: ""
 #   compress_data: 1
+#   auto_expire_lifetime: 604800
+#   auto_expire_pattern: /^.*/
 
 # magento_cache_frontend_default_backend: Cm_Cache_Backend_Redis
 
@@ -242,6 +244,8 @@ magento_x_frame_options: "SAMEORIGIN"
 #   database: 0
 #   password: ""
 #   compress_data: "0"
+#   auto_expire_lifetime: 604800
+#   auto_expire_pattern: /^.*/
 
 ## The Varnish compatible hosts that are used to store the full page configuration
 ## This appears to be undocumented, though is set with the CLI initially

--- a/templates/etc/env.php.j2
+++ b/templates/etc/env.php.j2
@@ -16,6 +16,8 @@ return array (
           'database' => '{{ magento_cache_frontend_default_backend_options.database }}',
           'password' => '{{ magento_cache_frontend_default_backend_options.password }}',
           'compress_data' => '{{ magento_cache_frontend_default_backend_options.compress_data }}',
+          'auto_expire_lifetime' => '{{ magento_cache_frontend_default_backend_options.auto_expire_lifetime }}',
+          'auto_expire_pattern' => '{{ magento_cache_frontend_default_backend_options.auto_expire_pattern }}',
         ),
       ),
       {% endif %}
@@ -30,6 +32,8 @@ return array (
           'database' => '{{ magento_cache_frontend_page_cache_backend_options.database }}',
           'password' => '{{ magento_cache_frontend_page_cache_backend_options.password }}',
           'compress_data' => '{{ magento_cache_frontend_page_cache_backend_options.compress_data }}',
+          'auto_expire_lifetime' => '{{ magento_cache_frontend_page_cache_backend_options.auto_expire_lifetime }}',
+          'auto_expire_pattern' => '{{ magento_cache_frontend_page_cache_backend_options.auto_expire_pattern }}',
         ),
       ),
       {% endif %}


### PR DESCRIPTION
we had a problem since a while that magento was not setting TTL on cache
entries in Redis, on some systems that results in Redis cache database
growing to huge numbers, like 16GB and starting to hit container/server
limitations.

After going with xdebung through magento core it became clear that
magento actually has a feature to control that, i.e. to force the
expiry.

See

    Cm_Cache_Backend_Redis::save()
    Cm_Cache_Backend_Redis::_getAutoExpiringLifetime()
    https://magento.stackexchange.com/questions/299854/redis-keys-are-keep-increasing-expiry-is-not-set-to-keys
    https://jmaitrehenry.ca/2017/11/22/found-keys-without-expiration-in-redis/

setting conditional breakpoints with xDebug we are always saving to
redis with expiration now, still we have ~10% of keys that don't have
TTL in Redis with those settings applied. At this moment I can not
explain that. Before this, something like 90% of keys in page_cache and
default cache backends were set without expiration.

Interesting enough, session cache backend is a different class and it
handles expiration better - there we always have 100% of keys with TTL
set.