### PR TITLE
ADHOC feat queue-cron-management: add wait for consumers var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -289,6 +289,10 @@ magento_upgrade_commands:
 ## See https://magento.stackexchange.com/questions/285385/magento-2-3-2-ce-and-cron-jobs-flock-and-rabbitmq/285386#285386
 magento_run_message_queue_consumers_separately: false
 
+## in case you don't want message queue consumers to wait for messages - change this to false
+## Changing it to false reduces server memory consuption but increases the waiting time for messages to be processed.
+magento_queue_consumers_wait_for_messages: true
+
 magento_queue_consumers_cron_template: "/usr/bin/php {{ magento_app_root }}/bin/magento queue:consumers:start {{ item.name }}"
 
 ## Deletes all installed deployable magento packages except the 

--- a/templates/etc/env.php.j2
+++ b/templates/etc/env.php.j2
@@ -113,9 +113,10 @@ return array (
   array (
     'date' => '{{ magento_install_date }}',
   ),
-  {% if magento_queue_amqp is defined %}
   'queue' =>
   array (
+    'consumers_wait_for_messages' => {{ magento_queue_consumers_wait_for_messages }},
+    {% if magento_queue_amqp is defined %}
     'amqp' =>
     array (
       'host' => '{{ magento_queue_amqp.host }}',
@@ -125,8 +126,8 @@ return array (
       'virtualhost' => '{{ magento_queue_amqp.virtualhost }}',
       'ssl' => '{{ magento_queue_amqp.ssl }}',
     ),
+    {% endif %}
   ),
-  {% endif %}
   {% if magento_run_message_queue_consumers_separately %}
   'cron_consumers_runner' => array(
       'cron_run' => false


### PR DESCRIPTION
as the comment states it: sometimes we don't want our consumers to wait
for messages, cause it allows to reduce project memory usage.