### PR TITLE
ADHOC [feat]: reorder tasks to install core config data before setup …

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -181,13 +181,6 @@
   command: "/usr/bin/php {{ magento_app_root }}/bin/magento setup:db-schema:upgrade"
   when: magento_db_status.stdout_lines|length == 0
 
-- name: "Perform any schema upgrades that are required"
-  become: "yes"
-  become_user: "{{ magento_user }}"
-  # "--keep-generated" is used as it's the responsibility of the build environment to do the application compilation.
-  command: "/usr/bin/php {{ magento_app_root }}/bin/magento {{ item }}"
-  with_items: "{{ magento_upgrade_commands }}"
-
 - name: "Enforce core configuration data"
   shell:
     cmd: |
@@ -204,6 +197,13 @@
           ;
       EOF
   with_items: "{{ magento_core_config_data }}"
+
+- name: "Perform any schema upgrades that are required"
+  become: "yes"
+  become_user: "{{ magento_user }}"
+  # "--keep-generated" is used as it's the responsibility of the build environment to do the application compilation.
+  command: "/usr/bin/php {{ magento_app_root }}/bin/magento {{ item }}"
+  with_items: "{{ magento_upgrade_commands }}"
 
 - name: "Configure webSSO"
   become: "yes"


### PR DESCRIPTION
…upgrade command

  Running setup upgrade before adding config data can lead into problems and cause the
  upgrade command to crash.

  Example for this is when Elasticsearch runs on a third party cluster or node, it
  requires configuration for the host and port to be present otherwise it defaults
  to localhost, however setup upgrade command can not complete if connection to
  elasticsearch can not be established

  This comit switches the order of those two tasks, making sure that all configuration
  is present in the database before running setup uprgrade.