### PR TITLE
ADHOC feat async-import: make things faster through parallel run

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -332,7 +332,13 @@ magento_force_reindex_on_deploy: False
 # when clones are cleaned up asynchronously, role is not checking successful execution
 magento_allow_async_cleanup_old_clones: false
 
+# timeout for async old clones cleanup, seconds
+magento_async_cleanup_old_clones_timeout: 600
+
 # allows to run magento reindexing asynchronously,
 # this allows pipeline to finish faster due to "parallel" execution of tasks
 # when reindexing is done asynchronously, role is not checking successful execution
 magento_allow_async_reindex: false
+
+# timeout for async reindex execution, seconds
+magento_async_reindex_timeout: 600

--- a/tasks/cleanup-old-clones.yml
+++ b/tasks/cleanup-old-clones.yml
@@ -13,7 +13,7 @@
     state: absent
   when: magento_cleanup_old_clones and magento_allow_async_cleanup_old_clones
   with_items: "{{ (magento_clones_for_cleanup.files | sort(attribute='ctime', reverse=True))[magento_clones_to_keep:] | list }}"
-  async: 600
+  async: "{{ magento_async_cleanup_old_clones_timeout }}"
   poll: 0
 
 - name: "Remove old clones/releases synchronously"

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -221,7 +221,7 @@
   become_user: "{{ magento_user }}"
   command: "/usr/bin/php {{ magento_app_root }}/bin/magento indexer:reindex"
   when: (magento_db_status.stdout_lines|length == 0 or magento_force_reindex_on_deploy == True) and magento_allow_async_reindex
-  async: 600
+  async: "{{ magento_async_reindex_timeout }}"
   poll: 0
 
 - name: "Let Magento indexer run synchronously"


### PR DESCRIPTION
if task is imported asyncronously - playbook can proceed with other
tasks, in the use cases here, I don't think we need to check back if
task has finished successfully, if this is a concern - don't allow async
execution

see:
* https://www.treitos.com/blog/2020/improving-ansible-performance.html
* https://docs.ansible.com/ansible/2.9/user_guide/playbooks_async.html
* https://docs.ansible.com/ansible/latest/user_guide/playbooks_handlers.html