### PR TITLE
ADHOC [feat]: add support for custom mysql port

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -123,6 +123,7 @@ magento_mode: "default"
 #  password: ""
 #  host: ""
 #  name: ""
+#  port: ""
 
 ## The database connections that contain the Magento data that Magento accesses
 ## See http://devdocs.magento.com/guides/v2.0/config-guide/config/config-php.html

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -170,7 +170,7 @@
 - name: "Check if Magento database exists"
   shell:
     cmd: |
-      mysql --user="{{ magento_config_db.username }}" --password="{{ magento_config_db.password }}" --database="{{ magento_config_db.name }}" --host="{{ magento_config_db.host }}" <<EOF
+      mysql --user="{{ magento_config_db.username }}" --password="{{ magento_config_db.password }}" --database="{{ magento_config_db.name }}" --host="{{ magento_config_db.host }}" --port="{{ magento_config_db.port | default('3306') }}" <<EOF
         SHOW TABLES LIKE 'core_config_data';
       EOF
   register: magento_db_status
@@ -184,7 +184,7 @@
 - name: "Enforce core configuration data"
   shell:
     cmd: |
-      mysql --user="{{ magento_config_db.username }}" --password="{{ magento_config_db.password }}" --database="{{ magento_config_db.name }}" --host="{{ magento_config_db.host }}" <<EOF
+      mysql --user="{{ magento_config_db.username }}" --password="{{ magento_config_db.password }}" --database="{{ magento_config_db.name }}" --host="{{ magento_config_db.host }}" --port="{{ magento_config_db.port | default('3306') }}" <<EOF
         INSERT INTO core_config_data (path, scope, scope_id, value)
           VALUES (
              '{{ item.path }}',


### PR DESCRIPTION
  Currently there is no support for custom mysql ports. Magento can be configured with port as part of the host directive,
  however this is not valid for operations performed directly on the cli.

  To solve the issue we are introducing declaration of port when required, this is optional and backwards compatible.